### PR TITLE
catch http errors for empty repos

### DIFF
--- a/lib/github_archive/archive_repos.rb
+++ b/lib/github_archive/archive_repos.rb
@@ -37,8 +37,12 @@ module GithubArchive
       end
       return if dry_run
       @client = GithubArchive::Auth.new(token).client
-      File.open(File.join(path, "#{repo[:name]}.tgz"), 'wb') do |f|
-        f.write open(@client.archive_link(repo[:full_name])).read
+      begin
+        File.open(File.join(path, "#{repo[:name]}.tgz"), 'wb') do |f|
+          f.write open(@client.archive_link(repo[:full_name])).read
+        end
+      rescue OpenURI::HTTPError
+        puts $!.message
       end
     end
   end


### PR DESCRIPTION
if a repo has no code, but exists in the organization, the archive fails.

```
$HOME/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:359:in `open_http': 404 Not Found (OpenURI::HTTPError)
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:737:in `buffer_open'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:212:in `block in open_loop'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:210:in `catch'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:210:in `open_loop'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:151:in `open_uri'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:717:in `open'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/open-uri.rb:35:in `open'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:42:in `block in copy_repo'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:41:in `open'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:41:in `copy_repo'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:21:in `block (2 levels) in archive'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:20:in `each'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:20:in `block in archive'
	from /Users/bradclark/.rvm/rubies/ruby-2.3.3/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/archive_repos.rb:19:in `archive'
	from /Users/bradclark/code/maxwell/github_archive/lib/github_archive/organization/repos.rb:29:in `archive'
	from ./exe/github-archive:52:in `org_repos'
	from /Users/bradclark/.rvm/gems/ruby-2.3.3/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/bradclark/.rvm/gems/ruby-2.3.3/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/bradclark/.rvm/gems/ruby-2.3.3/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/bradclark/.rvm/gems/ruby-2.3.3/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from ./exe/github-archive:92:in `<main>'
```